### PR TITLE
bump v2 to v3 lock.yml

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,10 +11,10 @@ jobs:
     name: 🔒 Lock closed issues and PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2.0.3
+      - uses: dessant/lock-threads@v3
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: "30"
+          issue-inactive-days: "30"
           issue-lock-reason: ""
-          pr-lock-inactive-days: "1"
+          pr-inactive-days: "1"
           pr-lock-reason: ""


### PR DESCRIPTION
 Breaking changes: v2 to v3
> input parameter names have changed

Ref: https://github.com/dessant/lock-threads/blob/08e671be8ac8944d0e132aa71d0ae8ccfb347675/CHANGELOG.md#300-2021-09-27
   
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Unexpected input(s): 'issue-lock-inactive-days', 'pr-lock-inactive-days'.

Issue Number: N/A

## What is the new behavior?

Renamed following input parameters to allow upgrading from v2 to v3:

- issue-lock-inactive-days --> issue-inactive-days
- pr-lock-inactive-days --> pr-inactive-days

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
